### PR TITLE
suggests either upcoming game-data-packager or generated data .deb

### DIFF
--- a/arx-libertatis/deb/control
+++ b/arx-libertatis/deb/control
@@ -12,6 +12,7 @@ Package: arx-libertatis
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}
 Recommends: arxcrashreporter
+Suggests: arx-fatalis-data | arx-fatalis-demo-data | game-data-packager (>= 41)
 Description: Cross-platform port of Arx Fatalis, a first-person role-playing game
  Arx Libertatis is a cross-platform port of the GPLed Arx Fatalis first-person
  role-playing game. This package only includes the game executable - you will


### PR DESCRIPTION
the name & install-location of packages generated by G-D-P
is engine-agnostic: e.g. opentyrian gets a tyrian-data .deb
so this data package should really be named arx-fatalis-...

/usr/share/games/arx dta location is already fine
and doesn't need to be changed

https://github.com/a-detiste/game-data-packager/blob/master/data/arx.yaml
